### PR TITLE
break read-loop on ERROR frame 

### DIFF
--- a/src/main/Stomp.php
+++ b/src/main/Stomp.php
@@ -536,6 +536,9 @@ class Stomp
             if (strpos($data, "\x00") !== false) {
                 $end = true;
                 $data = rtrim($data, "\n");
+            } elseif (strpos($data, 'ERROR') === 0) {
+                $end = true;
+                $data = rtrim($data, "\n");
             }
             $len = strlen($data);
         } while ($len < 2 || $end == false);


### PR DESCRIPTION
i stumbled over an error regarding ERROR frames received after an unsuccessful SEND to an apache activemq server. (this might actually be an apache activemq implementation error):
1. send a message with valid credentials to an activemq queue you're not allowed to send to (a queue that does not exist works too).
2. the server replies with an ERROR frame which is read via two fread() calls:
   1st fread():
   E
   2nd fread():
   RROR
   message:User xyz is not authorized to write to: queue:///queue/xyz```
   receipt-id:bbf1beb68e8634cb291687da3a182a8b
   
   java.lang.SecurityException: User xyz is not authorized to write to: queue:///queue/xyz
       at org.apache.activemq.security.AuthorizationBroker.send(AuthorizationBroker.java:187)
       at org.apache.activemq.broker.MutableBrokerFilter.send(MutableBrokerFilter.java:135)
       at org.apache.activemq.broker.TransportConnection.processMessage(TransportConnection.java:458)
       at org.apache.activemq.command.ActiveMQMessage.visit(ActiveMQMessage.java:681)
       at org.apache.activemq.broker.TransportConnection.service(TransportConnection.java:306)
       at org.apache.activemq.broker.TransportConnection$1.onCommand(TransportConnection.java:179)
       at org.apache.activemq.transport.TransportFilter.onCommand(TransportFilter.java:69)
       at org.apache.activemq.transport.InactivityMonitor.onCommand(InactivityMonitor.java:227)
       at org.apache.activemq.transport.stomp.StompTransportFilter.sendToActiveMQ(StompTransportFilter.java:81)
3. the original loop does not break because of the missing "\x00". thus the 3rd fread() "hangs" until socket_timeout is reached.

i'm running apache-activemq-5.5.0 and this could as well be a bug in the server.

cheers,
raoul
