### PR TITLE
bug fix for Stomp::readFrame, was occasionally reading more than one Frame

### DIFF
--- a/src/FuseSource/Stomp/Stomp.php
+++ b/src/FuseSource/Stomp/Stomp.php
@@ -563,7 +563,7 @@ class Stomp
         $end = false;
 
         do {
-            $read = fread($this->_socket, $rb);
+            $read = fgets($this->_socket, $rb);
             if ($read === false || $read === "") {
                 $this->_reconnect();
                 return $this->readFrame();


### PR DESCRIPTION
fread reads up to specified number of bytes or EOF.
fgets reads up to "\n", number of bytes or EOF.

The problem with fread is that if there is more than one Frame
on the socket, it will read the current Frame and part of the next
Frame.  Stomp::readFrame() is expected to just read the next Frame.
