### PR TITLE
Functions to override default stomp connection timeout and attempts

### DIFF
--- a/src/FuseSource/Stomp/Stomp.php
+++ b/src/FuseSource/Stomp/Stomp.php
@@ -532,6 +532,26 @@ class Stomp
     }
 
     /**
+     * Set timeout to wait for connection
+     *
+     * @param int $seconds Seconds to wait for connection
+     */
+    public function setConnectionTimeout($seconds)
+    {
+        $this->_connect_timeout_seconds = $seconds;
+    }
+
+    /**
+     * Set maximum number of connection attempts
+     *
+     * @param int $maxAttempts number of attempts
+     */
+    public function setMaxAttempts($maxAttempts)
+    {
+        $this->_attempts = $maxAttempts;
+    }
+
+    /**
      * Set timeout to wait for content to read
      *
      * @param int $seconds_to_wait  Seconds to wait for a frame


### PR DESCRIPTION
Adds new functions as requested and proposed in issue #19. Would be nice to have these for default overrides.